### PR TITLE
HMD latency fixes for yaw/position, less juddery position

### DIFF
--- a/Sources/CryGame C++/Solution1/CryGame/VRManager.cpp
+++ b/Sources/CryGame C++/Solution1/CryGame/VRManager.cpp
@@ -70,6 +70,7 @@ struct VRManager::D3DResources
 VRManager::VRManager()
 {
 	m_d3d = new D3DResources;
+	m_hmdTransform = Matrix34::CreateIdentity();
 }
 
 
@@ -119,8 +120,11 @@ bool VRManager::Init(CXGame *game)
 	m_inputReady = m_input.Init(game);
 	m_vrHaptics.Init(game, &m_input);
 
+	m_hmdTransform = Matrix34::CreateIdentity();
 	m_referencePosition = Vec3(0, 0, 0);
 	m_referenceYaw = 0;
+	m_uncommittedReferenceYaw = 0;
+	m_uncommittedReferencePosition = Vec3(0, 0, 0);
 
 	m_initialized = true;
 	return true;
@@ -633,8 +637,8 @@ Matrix34 VRManager::GetControllerTransform(int hand)
 
 void VRManager::UpdatePlayerTurnOffset(float yawDeltaDeg)
 {
-	m_referenceYaw += DEG2RAD(yawDeltaDeg);
-	UpdateHmdTransform();
+	m_uncommittedReferenceYaw += DEG2RAD(yawDeltaDeg);
+	//UpdateHmdTransform();
 }
 
 void VRManager::UpdatePlayerMoveOffset(const Vec3& offset, const Ang3& hmdAnglesDeg)
@@ -645,7 +649,19 @@ void VRManager::UpdatePlayerMoveOffset(const Vec3& offset, const Ang3& hmdAngles
 
 	Vec3 rawOffset = refTransform * offset;
 	rawOffset.z = 0;
-	m_referencePosition += rawOffset;
+	m_uncommittedReferencePosition += rawOffset;
+	UpdateHmdTransform();
+}
+
+void VRManager::OnPostPlayerCameraUpdate() 
+{
+	CommitYawAndOffsetChanges();
+}
+
+void VRManager::CommitYawAndOffsetChanges() 
+{
+	m_referenceYaw = m_uncommittedReferenceYaw;
+	m_referencePosition = m_uncommittedReferencePosition;
 	UpdateHmdTransform();
 }
 

--- a/Sources/CryGame C++/Solution1/CryGame/VRManager.h
+++ b/Sources/CryGame C++/Solution1/CryGame/VRManager.h
@@ -54,6 +54,9 @@ public:
 	void UpdatePlayerTurnOffset(float yawDeltaDeg);
 	void UpdatePlayerMoveOffset(const Vec3& offset, const Ang3& hmdAnglesDeg);
 
+	void OnPostPlayerCameraUpdate();
+	void CommitYawAndOffsetChanges();
+
 	VRHaptics* GetHaptics() { return &m_vrHaptics; }
 
 private:
@@ -111,7 +114,9 @@ private:
 	VRHaptics m_vrHaptics;
 
 	Vec3 m_referencePosition;
+	Vec3 m_uncommittedReferencePosition;
 	float m_referenceYaw = 0;
+	float m_uncommittedReferenceYaw = 0;
 	Matrix34 m_hmdTransform;
 	bool m_skippedRoomscaleMovement = false;
 	bool m_wasInMenu = false;

--- a/Sources/CryGame C++/Solution1/CryGame/XPlayerCamera.cpp
+++ b/Sources/CryGame C++/Solution1/CryGame/XPlayerCamera.cpp
@@ -22,6 +22,8 @@
 #include "WeaponSystemEx.h"
 #include <float.h>
 
+#include "VRManager.h"
+
 //////////////////////////////////////////////////////////////////////////
 /*! Updates the lean angles 
 */
@@ -308,6 +310,10 @@ void CPlayer::UpdateCamera()
 
 	if (camera)
 		camera->Update();
+
+	// Must be done here to reduce latency.
+	if (IsMyPlayer())
+		gVR->OnPostPlayerCameraUpdate();
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I had fun while playing this, but couldn't help but notice a wobbly latency when rotating my headset, only affecting the yaw but not the pitch. Took a bit to dig through the source to figure out what was going on, but it should be fixed now. It makes the position a bit more consistent/less laggy too. Should feel more like a native VR game, but I don't believe the position is 100% perfect yet latency wise, the yaw is though.

Feedback/quick testing for some regressions would be helpful, but didn't notice anything out of the ordinary.

